### PR TITLE
fix(LIN-65): add missing organizationId to enhanced response integration test

### DIFF
--- a/tests/agent/enhanced-response-integration.test.ts
+++ b/tests/agent/enhanced-response-integration.test.ts
@@ -41,7 +41,8 @@ describe('Enhanced Response Integration', () => {
   beforeEach(async () => {
     agentSystem = new EnhancedAgentSystem({
       linear: {
-        apiKey: 'test-api-key'
+        apiKey: 'test-api-key',
+        organizationId: 'test-org-id'
       },
       behaviors: {
         enabled: true


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation error in enhanced response integration test
- Added required `organizationId` parameter to `EnhancedAgentSystem` configuration
- Verified no other test files need similar fixes

## Context
The `EnhancedAgentConfig` interface requires both `apiKey` and `organizationId` in the linear configuration object, but the test was missing the `organizationId` parameter. This was causing TypeScript compilation failures.

## Changes Made
- Added `organizationId: 'test-org-id'` to the test configuration in `tests/agent/enhanced-response-integration.test.ts`
- Verified that no other test files use `EnhancedAgentSystem` or similar configurations requiring this parameter

## Test Plan
- [x] TypeScript compilation now succeeds
- [x] Test file runs (though some tests fail due to mock setup issues unrelated to this fix)
- [x] Checked all other test files with linear configurations - none require similar fixes

## Linear Issue
Fixes LIN-65: Enhanced Response Integration Test Configuration
https://linear.app/wordstofilmby/issue/LIN-65

🤖 Generated with [Claude Code](https://claude.ai/code)